### PR TITLE
readme: arch; iptables-save, optional update

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ sudo /etc/init.d/netfilter-persistent save
 ### Arch Linux Distributions
 *Use iptable-save which is pre-installed*
 ```
-sudo iptables-save > /etc/iptables/iptables.rules
+sudo iptables-save | sudo tee /etc/iptables/iptables.rules
 ```
 ### RHEL / CentOS Distributions
 *This is by far the simpliest way to save rules and check them # chkconfig --list | grep iptables*


### PR DESCRIPTION
@ChrisTitusTech Hi, this one is optional; this one-liner doesn't need to change permissions to the rule file.
Because by default

```
$ sudo iptables-save > /etc/iptables/iptables.rules
zsh|bash: permission denied: /etc/iptables/iptables.rules
```